### PR TITLE
This will load at least some heroes to the hero board.

### DIFF
--- a/scripts/npc/herolist.txt
+++ b/scripts/npc/herolist.txt
@@ -5,4 +5,28 @@
 
 "CustomHeroList"
 {
+	"npc_dota_hero_axe"			"1"
+	"npc_dota_hero_pudge"			"1"
+	"npc_dota_hero_windrunner"		"1"
+	"npc_dota_hero_omniknight"		"1"
+	"npc_dota_hero_nevermore"		"1"	// Shadow Fiend
+	"npc_dota_hero_shadow_shaman"		"1"
+	"npc_dota_hero_juggernaut"		"1"
+	"npc_dota_hero_crystal_maiden"		"1"
+	"npc_dota_hero_drow_ranger"		"1"
+	"npc_dota_hero_venomancer"		"1"
+	"npc_dota_hero_sven"			"1"
+	"npc_dota_hero_jakiro"			"1"
+	"npc_dota_hero_magnataur"		"1"
+	"npc_dota_hero_legion_commander"	"1"
+	"npc_dota_hero_lina"			"1"
+	"npc_dota_hero_puck"			"0"
+	"npc_dota_hero_tidehunter"		"0"
+	"npc_dota_hero_sand_king"		"1"
+	"npc_dota_hero_kunkka"			"0"
+	"npc_dota_hero_elder_titan"		"1"
+	"npc_dota_hero_storm_spirit"		"1"
+	"npc_dota_hero_queenofpain"		"1"
+	"npc_dota_hero_witch_doctor"	"1"
+	"npc_dota_hero_templar_assassin"	"1"
 }


### PR DESCRIPTION
Without herolost, the heropicker stays empty. And this doens't let anyone set their heroes up. This makes it possible.

Thanks to kobb, it is his file.
