### PR TITLE
Documentation Fix - for Mod Events wrong key values were corrected

### DIFF
--- a/scripts/vscripts/gamemodes.lua
+++ b/scripts/vscripts/gamemodes.lua
@@ -16,10 +16,10 @@
         - "player"          "short"
         - "abilityname"     "string"
     - dota_player_learned_ability
-        - "player"        	"short"
+        - "player"          "short"
         - "abilityname"     "string"
     - dota_player_gained_level
-        - "player"        	"short"
+        - "player"          "short"
         - "level"           "short"
     - dota_item_purchased
         - "PlayerID"        "short"


### PR DESCRIPTION
dota_player_used_ability,
dota_player_learned_ability,
dota_player_gained_level,
The key is "player" instead of "PlayerID".

dota_item_picked_up,
Two more keys namely "ItemEntityIndex" and
"HeroEntityIndex".
